### PR TITLE
ci: build installer and rayhunter-check for armv7

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -15,6 +15,10 @@ rustflags = ["-C", "target-feature=+crt-static"]
 linker = "rust-lld"
 rustflags = ["-C", "target-feature=+crt-static"]
 
+[target.armv7-unknown-linux-musleabi]
+linker = "rust-lld"
+rustflags = ["-C", "target-feature=+crt-static"]
+
 # Disable rust-lld for x86 macOS because the linker crashers when compiling
 # the installer in release mode with debug info on.
 # [target.x86_64-apple-darwin]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
             target: x86_64-unknown-linux-musl
           - name: linux-armv7
             os: ubuntu-latest
-            target: armv7-unknown-linux-musleabihf
+            target: armv7-unknown-linux-musleabi
           - name: linux-aarch64
             os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
@@ -272,7 +272,7 @@ jobs:
             target: x86_64-unknown-linux-musl
           - name: linux-armv7
             os: ubuntu-latest
-            target: armv7-unknown-linux-musleabihf
+            target: armv7-unknown-linux-musleabi
           - name: linux-aarch64
             os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,6 +160,9 @@ jobs:
           - name: linux-x64
             os: ubuntu-latest
             target: x86_64-unknown-linux-musl
+          - name: linux-armv7
+            os: ubuntu-latest
+            target: armv7-unknown-linux-musleabihf
           - name: linux-aarch64
             os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
@@ -175,13 +178,16 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform.target }}
       - uses: Swatinem/rust-cache@v2
       - name: Build rayhunter-check
-        run: cargo build --bin rayhunter-check --release
+        run: cargo build --bin rayhunter-check --release --target ${{ matrix.platform.target }}
       - uses: actions/upload-artifact@v4
         with:
           name: rayhunter-check-${{ matrix.platform.name }}
-          path: target/release/rayhunter-check${{ matrix.platform.os == 'windows-latest' && '.exe' || '' }}
+          path: target/${{ matrix.platform.target }}/release/rayhunter-check${{ matrix.platform.os == 'windows-latest' && '.exe' || '' }}
           if-no-files-found: error
 
   build_rootshell:
@@ -198,7 +204,7 @@ jobs:
         with:
           targets: armv7-unknown-linux-musleabihf
       - uses: Swatinem/rust-cache@v2
-      - name: Build rootshell (arm32)
+      - name: Build rootshell (armv7)
         run: cargo build --bin rootshell --target armv7-unknown-linux-musleabihf --profile=firmware
       - uses: actions/upload-artifact@v4
         with:
@@ -227,7 +233,7 @@ jobs:
         with:
           targets: armv7-unknown-linux-musleabihf
       - uses: Swatinem/rust-cache@v2
-      - name: Build rayhunter-daemon (arm32)
+      - name: Build rayhunter-daemon (armv7)
         run: |
           pushd bin/web
           npm install
@@ -264,6 +270,9 @@ jobs:
           - name: linux-x64
             os: ubuntu-latest
             target: x86_64-unknown-linux-musl
+          - name: linux-armv7
+            os: ubuntu-latest
+            target: armv7-unknown-linux-musleabihf
           - name: linux-aarch64
             os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
@@ -306,6 +315,7 @@ jobs:
         platform:
           - linux-x64
           - linux-aarch64
+          - linux-armv7
           - macos-intel
           - macos-arm
           - windows-x86_64

--- a/doc/installing-from-release.md
+++ b/doc/installing-from-release.md
@@ -5,6 +5,7 @@ Make sure you've got one of Rayhunter's [supported devices](./supported-devices.
 1. Download the latest `rayhunter-vX.X.X-PLATFORM.zip` from the [Rayhunter releases page](https://github.com/EFForg/rayhunter/releases) for your platform:
     - for Linux on x64 architecture: `linux-x64`
     - for Linux on ARM64 architecture: `linux-aarch64`
+    - for Linux on armv7/v8 (32-bit) architecture: `linux-armv7`
     - for MacOS on Intel (old macbooks) architecture: `macos-intel`
     - for MacOS on ARM (M1/M2 etc.) architecture: `macos-arm`
     - for Windows: `windows-x86_64`

--- a/doc/installing-from-source.md
+++ b/doc/installing-from-source.md
@@ -25,8 +25,9 @@ rustup target add armv7-unknown-linux-musleabihf
 # check which toolchain you have installed by default with
 rustup show
 # now install the correct variant for your host platform, one of:
-rustup target add x86_64-unknown-linux-musl
 rustup target add aarch64-unknown-linux-musl
+rustup target add armv7-unknown-linux-musleabi
+rustup target add x86_64-unknown-linux-musl
 rustup target add aarch64-apple-darwin
 rustup target add x86_64-apple-darwin
 rustup target add x86_64-pc-windows-gnu


### PR DESCRIPTION
Support installing on aarch32/armv7 linux systems, such as 32bit raspberry pis and beaglebones.

This branch changes the installer names from "ubuntu" to "linux", as they are statically linked and not dependent on any particular linux distribution.